### PR TITLE
Disable or enable implicit animations

### DIFF
--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -16,6 +16,7 @@ class MyCircleProgressButton: CircleProgressButton {
     init(defaultIconTintColor: UIColor) {
         self.iconTintColor = defaultIconTintColor
         super.init(frame: .zero)
+        animated = false
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -130,8 +131,10 @@ class ViewController : UIViewController {
                 self.button.strokeMode = .border(width: 4)
                 self.updatePeriodically()
             } else {
-                self.button.strokeMode = .fill
-                self.button.complete()
+                self.button.animate {
+                    self.button.strokeMode = .fill
+                    self.button.complete()
+                }
             }
         }
     }

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -67,9 +67,9 @@ class ViewController : UIViewController {
         view.backgroundColor = .white
 
         button.backgroundColor = .clear
-        button.inProgressStrokeColor = UIColor(hex: 0xFFF211)
+        button.inProgressStrokeColor = UIColor(hex: 0x0044C3)
         button.suspendedStrokeColor = UIColor(hex: 0x8C8C8C)
-        button.completedStrokeColor = UIColor(hex: 0xFFF211)
+        button.completedStrokeColor = UIColor(hex: 0x0044C3)
         button.isDebugEnabled = true
         button.translatesAutoresizingMaskIntoConstraints = false
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ UIView based circle button with CAShapeLayer based progress stroke.
 ![](https://github.com/toshi0383/assets/blob/master/CircleProgressButton/circle-progress-button.gif)
 ![](https://github.com/toshi0383/assets/blob/master/CircleProgressButton/border-progress.gif)
 ![](https://github.com/toshi0383/assets/blob/master/CircleProgressButton/dashed-yellow-circle.gif)
+![](https://github.com/toshi0383/assets/blob/master/CircleProgressButton/blue-circle-less-animations.gif)
+
 ![platforms](https://img.shields.io/badge/platforms-iOS-yellow.svg)
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 [![Cocoapods](https://img.shields.io/badge/Cocoapods-compatible-brightgreen.svg)](https://cocoapods.org)
@@ -30,6 +32,7 @@ Actually there's no `default` appearance, so have fun.👋
     open var completedStrokeColor: UIColor?
     open var strokeMode: StrokeMode = .fill
     open var touchedAlpha: CGFloat = 0.5
+    public var animated: Bool = true
 ```
 
 UIImage's `contentMode` is `.center`. Make sure you provide correct size of image.
@@ -42,6 +45,13 @@ UIImage's `contentMode` is `.center`. Make sure you provide correct size of imag
 
 It is possible to update progress while suspended.  
 `state` is read-only. Update via `suspend()`, `resume()`, `complete()` and `reset()`.
+
+## Disable/Enable Animations
+By default implicit CALayer's animations are enabled.
+You can disable this behavior either by
+
+- setting `animated` property false
+- Use `CircleProgressButton#animate(_:)` or `CircleProgressButton#performWithoutAnimation(_:)`
 
 ## Handle Tap
 ```swift


### PR DESCRIPTION
# Before
![dashed-yellow-circle](https://user-images.githubusercontent.com/6007952/35366190-872b8f62-01bb-11e8-8d7c-491b4a014908.gif)

# After
![blue-circle-less-animations](https://user-images.githubusercontent.com/6007952/35366181-7bdbcbcc-01bb-11e8-86ac-ea547ec55998.gif)

This example shows
- `animated` property set to false
- `complete()` inside `func animated(_:)` block